### PR TITLE
Create the argocd resources within the namespaces specified

### DIFF
--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-build.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-build.yaml
@@ -2,14 +2,14 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ${{ values.component_id }}-build
-  namespace: ${{ values.gitopsNamespace }}
+  namespace: ${{ values.appNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination:
     server: https://kubernetes.default.svc
-    namespace: ${{ values.gitopsNamespace }}
+    namespace: ${{ values.appNamespace }}
   source:
     repoURL: ${{ values.destination }}
     path: ./helm/build

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-build.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-build.yaml
@@ -16,7 +16,7 @@ spec:
     targetRevision: HEAD
     helm:
       values: |
-        app.namespace: ${{ values.appNamespace }}-build
+        app.namespace: ${{ values.appNamespace }}
   syncPolicy:
     automated:
       prune: true
@@ -25,6 +25,7 @@ spec:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true
       - ApplyOutOfSyncOnly=true
+      - FailOnSharedResource=false
     retry:
       backoff:
         duration: 5s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-db.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-db.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ${{ values.component_id }}-db
-  namespace: ${{ values.gitopsNamespace }}
+  namespace: ${{ values.appNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-db.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-db.yaml
@@ -38,4 +38,4 @@ spec:
         duration: 5s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
         factor: 2 # a factor to multiply the base duration after each failed retry
         maxDuration: 10m # the maximum amount of time allowed for the backoff strategy
-  {% endif %}
+{% endif %}

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-deploy.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-deploy.yaml
@@ -2,14 +2,14 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ${{ values.component_id }}-deploy
-  namespace: ${{ values.gitopsNamespace }}
+  namespace: ${{ values.appNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination:
     server: https://kubernetes.default.svc
-    namespace: ${{ values.gitopsNamespace }}
+    namespace: ${{ values.appNamespace }}
   source:
     repoURL: ${{ values.destination }}
     path: ./helm/deploy

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-test.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-test.yaml
@@ -16,7 +16,7 @@ spec:
     targetRevision: HEAD
     helm:
       values: |
-        app.namespace: ${{ values.appNamespace }}-test
+        app.namespace: ${{ values.appNamespace }}
   syncPolicy:
     automated:
       prune: true
@@ -25,6 +25,7 @@ spec:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true
       - ApplyOutOfSyncOnly=true
+      - FailOnSharedResource=false
     retry:
       backoff:
         duration: 5s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-test.yaml
+++ b/qshift/templates/quarkus-application/manifests/argocd/${{values.component_id}}-test.yaml
@@ -2,14 +2,14 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ${{ values.component_id }}-test
-  namespace: ${{ values.gitopsNamespace }}
+  namespace: ${{ values.appNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination:
     server: https://kubernetes.default.svc
-    namespace: ${{ values.gitopsNamespace }}
+    namespace: ${{ values.appNamespace }}
   source:
     repoURL: ${{ values.destination }}
     path: ./helm/test

--- a/qshift/templates/quarkus-application/manifests/helm/build/templates/01-cm-maven-settings.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/templates/01-cm-maven-settings.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: maven-settings
+  name: maven-settings-build
   namespace: {{ .Values.app.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "0"

--- a/qshift/templates/quarkus-application/manifests/helm/build/templates/01-pvc-m2-repo.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/templates/01-pvc-m2-repo.yaml
@@ -1,7 +1,7 @@
 ﻿kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: m2-repo-pvc
+  name: m2-repo-pvc-build
   namespace: {{ .Values.app.namespace }}
 spec:
   accessModes:

--- a/qshift/templates/quarkus-application/manifests/helm/build/templates/01-pvc-project.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/templates/01-pvc-project.yaml
@@ -1,7 +1,7 @@
 ﻿kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: project-pvc
+  name: project-pvc-build
   namespace: {{ .Values.app.namespace }}
 spec:
   accessModes:

--- a/qshift/templates/quarkus-application/manifests/helm/build/templates/03-pipelinerun-quarkus-buildah.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/templates/03-pipelinerun-quarkus-buildah.yaml
@@ -26,7 +26,7 @@ spec:
     - name: maven-m2-repo
       persistentVolumeClaim:
         claimName: m2-repo-pvc-build
-    - name: maven-settings-build
+    - name: maven-settings
       configMap:
         name: maven-settings-build
     - name: dockerconfig-ws

--- a/qshift/templates/quarkus-application/manifests/helm/build/templates/03-pipelinerun-quarkus-buildah.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/templates/03-pipelinerun-quarkus-buildah.yaml
@@ -22,13 +22,13 @@ spec:
   workspaces:
     - name: project-dir
       persistentVolumeClaim:
-        claimName: project-pvc
+        claimName: project-pvc-build
     - name: maven-m2-repo
       persistentVolumeClaim:
-        claimName: m2-repo-pvc
-    - name: maven-settings
+        claimName: m2-repo-pvc-build
+    - name: maven-settings-build
       configMap:
-        name: maven-settings
+        name: maven-settings-build
     - name: dockerconfig-ws
       secret:
         secretName: dockerconfig-secret

--- a/qshift/templates/quarkus-application/manifests/helm/build/values.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build/values.yaml
@@ -1,6 +1,6 @@
 app:
   name: ${{ values.component_id }}
-  namespace: ${{ values.appNamespace }}-build
+  namespace: ${{ values.appNamespace }}
   cluster:    #${{ values.cluster }}
 
 git:

--- a/qshift/templates/quarkus-application/manifests/helm/test/templates/01-cm-maven-settings.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/templates/01-cm-maven-settings.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: maven-settings
+  name: maven-settings-test
   namespace: {{ .Values.app.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "0"

--- a/qshift/templates/quarkus-application/manifests/helm/test/templates/01-pvc-m2-repo.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/templates/01-pvc-m2-repo.yaml
@@ -1,7 +1,7 @@
 ﻿kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: m2-repo-pvc
+  name: m2-repo-pvc-test
   namespace: {{ .Values.app.namespace }}
 spec:
   accessModes:

--- a/qshift/templates/quarkus-application/manifests/helm/test/templates/01-pvc-project.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/templates/01-pvc-project.yaml
@@ -1,7 +1,7 @@
 ﻿kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: project-pvc
+  name: project-pvc-test
   namespace: {{ .Values.app.namespace }}
 spec:
   accessModes:

--- a/qshift/templates/quarkus-application/manifests/helm/test/templates/03-pipelinerun-quarkus-test.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/templates/03-pipelinerun-quarkus-test.yaml
@@ -26,13 +26,13 @@ spec:
   workspaces:
     - name: project-dir
       persistentVolumeClaim:
-        claimName: project-pvc
+        claimName: project-pvc-test
     - name: maven-m2-repo
       persistentVolumeClaim:
-        claimName: m2-repo-pvc
+        claimName: m2-repo-pvc-test
     - name: maven-settings
       configMap:
-        name: maven-settings
+        name: maven-settings-test
     - name: dockerconfig-ws
       secret:
         secretName: dockerconfig-secret

--- a/qshift/templates/quarkus-application/manifests/helm/test/values.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/values.yaml
@@ -1,6 +1,6 @@
 app:
   name: ${{ values.component_id }}
-  namespace: ${{ values.appNamespace }}-test
+  namespace: ${{ values.appNamespace }}
   virtualMachineName: ${{ values.virtualMachineName }}
   virtualMachineNamespace: ${{ values.virtualMachineNamespace }}
   cluster:    #${{ values.cluster }}

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -308,6 +308,7 @@ spec:
       input:
         appName: ${{ parameters.component_id }}-bootstrap
         argoInstance: argocdQShift # Match appconfig => argocd/appLocatorMethods/instances/name
+        projectName: default
         namespace: ${{ parameters.namespace }}
         repoUrl: https://${{ parameters.repo.host }}/${{ parameters.repo.org }}/${{parameters.component_id}}.git
         path: 'argocd/'

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -277,13 +277,13 @@ spec:
           git_repo_name: ${{ parameters.component_id }}
           git_branch: main
           image_url: ${{ parameters.imageUrl }}
-          gitopsNamespace: openshift-gitops # TODO: To be investigated why we cannot use another namespace !
           appNamespace: ${{ parameters.namespace }}
           virtualMachineName: ${{ parameters.virtualMachineName }}
           virtualMachineNamespace: ${{ parameters.virtualMachineNamespace }}
           database: ${{ parameters.database }}
           database_username: postgres
           database_name: ${{ parameters.component_id}}-db
+          
     - id: publish
       name: Publishing to Code Source Repository - Github
       action: publish:github
@@ -308,9 +308,8 @@ spec:
       input:
         appName: ${{ parameters.component_id }}-bootstrap
         argoInstance: argocdQShift # Match appconfig => argocd/appLocatorMethods/instances/name
-        namespace: openshift-gitops
+        namespace: ${{ parameters.namespace }}
         repoUrl: https://${{ parameters.repo.host }}/${{ parameters.repo.org }}/${{parameters.component_id}}.git
-        # labelValue: ${{ parameters.name }}
         path: 'argocd/'
 
   output:

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -308,7 +308,7 @@ spec:
       input:
         appName: ${{ parameters.component_id }}-bootstrap
         argoInstance: argocdQShift # Match appconfig => argocd/appLocatorMethods/instances/name
-        projectName: default
+        projectName: ${{ parameters.component_id }}
         namespace: ${{ parameters.namespace }}
         repoUrl: https://${{ parameters.repo.host }}/${{ parameters.repo.org }}/${{parameters.component_id}}.git
         path: 'argocd/'


### PR DESCRIPTION
- Create the argocd resources within the namespace specified within the backstage template as parameter
- Deploy the tekton resources within the application namespace to avoid to have to create namespace-build, namespace-test
- Issue #10

Remark: This change will allow to install backstage (see q-shift/backstage-playground project) within the same namespace as argocd Applications CR