### PR TITLE
Replace the hard coded namespace with the appnamespace variable. #15

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/test/templates/01-clusterrolebinding-kubevirt-sa.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/test/templates/01-clusterrolebinding-kubevirt-sa.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: pipeline
-    namespace: qshift-test
+    namespace: {{ .Values.app.namespace }}


### PR DESCRIPTION
-  #15
- Replace the hard coded namespace with the `appNamespace` variable of the ClusterroleBinding resource for the sa pipeline