### PR TITLE
Change the enum value from nosql to none

### DIFF
--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -106,7 +106,7 @@ spec:
           type: string
           default: nosql
           enum:
-            - nosql
+            - none
             - quarkus-jdbc-postgresql
             - quarkus-jdbc-mysql
             - quarkus-jdbc-h2


### PR DESCRIPTION
- Change the enum value from `nosql` to `none` as the backstage quarkus plugin checks if the value of the database parameter exists and is not equal to `none`.
- See: #25 