### PR TITLE
Set the default value to none for the database enum

### DIFF
--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -104,7 +104,7 @@ spec:
         database:
           title: Select a database (optional)
           type: string
-          default: nosql
+          default: none
           enum:
             - none
             - quarkus-jdbc-postgresql


### PR DESCRIPTION
- Set the default value to none for the database enum
- See: #25