### PR TITLE
Only set the env var QUARKUS_DATASOURCE_PASSWORD when database is: qu…

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/deploy/templates/deployment.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/templates/deployment.yaml
@@ -34,12 +34,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if eq .Values.app.database "quarkus-jdbc-postgresql" }}
           env:
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: postgres-password
                   name: {{ .Values.app.name }}-db-postgresql
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.url }}

--- a/qshift/templates/quarkus-application/manifests/helm/deploy/values.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/values.yaml
@@ -5,6 +5,7 @@ app:
   name: ${{ values.component_id }}
   version: ${{ values.version }}
   namespace: ${{ values.appNamespace }}
+  database: ${{ values.database }}
 
 git:
   repo: ${{ values.git_repo }}


### PR DESCRIPTION
- Only set the env var `QUARKUS_DATASOURCE_PASSWORD` when database is `quarkus-jdbc-postgresql`
- See: #25 