### PR TITLE
Set the name of the Chart to ${{ values.component_id }}

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/deploy/Chart.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: quarkus-deploy
+name: ${{ values.component_id }}
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
- Set the name of the Chart to ${{ values.component_id }} to generate as k8s resource name: `release_name` instead of this too long name ` release_name-chart_name`.
- See:  #31