### PR TITLE
Use the name created using the Chart name instead of the full name

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/deploy/templates/deployment.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "quarkus-template.fullname" $ }}
+  name: {{ include "quarkus-template.name" $ }}
   namespace: "{{ .Values.app.namespace }}"
   annotations:
     {{- include "quarkus-template.annotations" . | nindent 4 }}

--- a/qshift/templates/quarkus-application/manifests/helm/deploy/templates/route.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/templates/route.yaml
@@ -6,7 +6,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
   labels:
     {{- include "quarkus-template.labels" $ | nindent 4 }}
-  name: {{ include "quarkus-template.fullname" $ }}
+  name: {{ include "quarkus-template.name" $ }}
   namespace: {{ include "quarkus-template.namespace" $ }}
 spec:
   {{- if .host }}
@@ -19,7 +19,7 @@ spec:
     targetPort: {{ $.Values.service.port }}
   to:
     kind: Service
-    name: {{ include "quarkus-template.fullname" $ }}
+    name: {{ include "quarkus-template.name" $ }}
   tls:
     termination: edge
   wildcardPolicy: None

--- a/qshift/templates/quarkus-application/manifests/helm/deploy/templates/service.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "quarkus-template.fullname" . }}
+  name: {{ include "quarkus-template.name" $ }}
   namespace: "{{ .Values.app.namespace }}"
   labels:
     {{- include "quarkus-template.labels" . | nindent 4 }}

--- a/qshift/templates/quarkus-application/manifests/helm/deploy/templates/serviceaccount.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/deploy/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "quarkus-template.serviceAccountName" . }}
+  name: {{ include "quarkus-template.serviceAccountName" $ }}
   namespace: "{{ .Values.app.namespace }}"
   labels:
     {{- include "quarkus-template.labels" . | nindent 4 }}


### PR DESCRIPTION
- Use the name created using the Chart name instead of the full name which is too long.
- Use the same convention to pass the context: . to $. within the include statements
- See: #31