### PR TITLE
Fix wrong snowdrop domain name: snowdrop.me to snowxdrop.dev.

### DIFF
--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -250,7 +250,7 @@ spec:
         url: skeletons/catalog-info/
         values:
           component_id: ${{ parameters.component_id }}
-          clusterDomainName: apps.qshift.snowdrop.me #TODO: Find a way to configure it
+          clusterDomainName: apps.qshift.snowdrop.dev #TODO: Find a way to configure it
           orgName: ${{ parameters.repo.org }}
           repoName: ${{ parameters.repo.name }}
           owner: ${{ parameters.owner }}


### PR DESCRIPTION
- Fix wrong snowdrop domain name: `snowdrop.me` -->  `snowdrop.dev`
- See: #9