### PR TITLE
Add parameters to the ui:field: QuarkusExtensionList to filter the extensions

### DIFF
--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -138,6 +138,14 @@ spec:
           type: array
           description: The list of alternative extensions
           ui:field: QuarkusExtensionList
+          ui:options:
+            # codeQuarkusUrl: https://code.quarkus.io
+            filter:
+              extensions:
+                - io.quarkus:quarkus-resteasy-reactive-jackson
+                - io.quarkus:quarkus-smallrye-openapi
+                - io.quarkus:quarkus-smallrye-graphql
+                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
 
         additionalProperties:
           title: Additional Properties


### PR DESCRIPTION
- Add parameters to the ui:field: QuarkusExtensionList to filter the list of the extensions
- !! This change will work as soon as we will release the version 0.1.24 of the plugin