### PR TITLE
Prefix the pipelineRun name with the componentID

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/build-test-push/templates/03-pipelinerun-quarkus-build-test-push.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build-test-push/templates/03-pipelinerun-quarkus-build-test-push.yaml
@@ -1,12 +1,13 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: quarkus-build-test-push
+  name: {{ .Values.app.name }}-build-test-push
   namespace: {{ .Values.app.namespace }}
   labels:
     {{- include "backstage.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/hook: Sync
 spec:
   pipelineRef:
     name: quarkus-build-test-push


### PR DESCRIPTION
- Prefix the pipelineRun name with the componentID to have unique names
- Issue #37