### PR TITLE
Remove duplicate key for field: Owner

### DIFF
--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -41,7 +41,6 @@ spec:
               kind:
                 - Group
                 - User
-          default: user:guest
         native:
           title: Quarkus native build
           type: boolean


### PR DESCRIPTION
- Remove duplicate key for field: Owner. 
- See: #44