### PR TITLE
Enable or disable the maven parameter: -Dquarkus.package.type=native-sources

### DIFF
--- a/qshift/templates/quarkus-application/manifests/helm/build-test-push/templates/02-pipeline-quarkus-build-test-push.yaml
+++ b/qshift/templates/quarkus-application/manifests/helm/build-test-push/templates/02-pipeline-quarkus-build-test-push.yaml
@@ -116,9 +116,9 @@ spec:
           value:
             - package
             - -B
-            - -Dquarkus.package.type=native-sources
             - -Dquarkus.openshift.deploy=false
-            - -Dquarkus.container-image.build=false
+            - -Dquarkus.container-image.build=false{{ if .Values.build.native }}
+            - -Dquarkus.package.type=native-sources{{ end }}
       workspaces:
         - name: maven-settings
           workspace: maven-settings


### PR DESCRIPTION
- Add a test to check if this is a `native` build and if this is case, then we include the parameter `-Dquarkus.package.type=native-sources`.
- Fix the issue reported as buildah build with Dockerfile failed as the jar, lib files `./target/quarkus-app/*` are not included anymore since 3.9 https://github.com/q-shift/backstage-playground/issues/82