### PR TITLE
Use static lists instead of dynamic for quarkus versions and extensions

### DIFF
--- a/qshift/all.yaml
+++ b/qshift/all.yaml
@@ -7,5 +7,6 @@ spec:
   targets:
     - ./org.yaml
     - ./entities.yaml
+    - ./templates/quarkus-application/template-static.yaml
     - ./templates/quarkus-application/template.yaml
     - ./templates/quarkus-quickstart/template.yaml

--- a/qshift/templates/quarkus-application/template-static.yaml
+++ b/qshift/templates/quarkus-application/template-static.yaml
@@ -26,6 +26,7 @@ spec:
           description: Unique name of the application
           default: my-quarkus-app
           ui:field: EntityNamePicker
+
         quarkusVersion:
           title: Quarkus version
           type: string
@@ -39,6 +40,7 @@ spec:
             - '3.2'
             - '3.8'
             - '3.10 (RECOMMENDED)'
+
         owner:
           title: Owner
           type: string
@@ -64,37 +66,43 @@ spec:
           type: string
           default: io.quarkus
           description: Maven Group ID eg (io.janus)
+
         artifactId:
           title: Artifact ID
           type: string
           default: my-quarkus-app
           description: Maven Artifact ID
+
         version:
           title: Version
           type: string
           default: 1.0.0-SNAPSHOT
           description: Maven Artifact Version
+
         java_package_name:
           title: Java Package Namespace
           type: string
           default: io.quarkus.demo
           description: Name for the Java Package (e.g. io.quarkus.demo)
+
         description:
           title: Description
           type: string
           description: Help others understand what this website is for.
           default: A cool quarkus app
+
         javaVersion:
           title: Java Version
           type: string
           description: Java version
-          default: '17'
+          default: '21'
           enum:
             - '17'
             - '21'
           enumNames:
             - Java 17
             - Java 21
+
         buildTool:
           title: Build Tool
           type: string
@@ -129,6 +137,7 @@ spec:
             - 'PostgreSQL'
             - 'MySQL'
             - 'H2'
+
         healthEndpoint:
           title: Enable health endpoint
           type: boolean
@@ -165,16 +174,6 @@ spec:
               - REST resources for Hibernate ORM with Panache
           uniqueItems: true
           ui:widget: checkboxes
-
-          #ui:field: QuarkusExtensionList
-          #ui:options:
-          #  # codeQuarkusUrl: https://code.quarkus.io
-          #  filter:
-          #    extensions:
-          #      - io.quarkus:quarkus-rest-jackson
-          #      - io.quarkus:quarkus-smallrye-openapi
-          #      - io.quarkus:quarkus-smallrye-graphql
-          #      - io.quarkus:quarkus-hibernate-orm-rest-data-panache
 
         additionalProperties:
           title: Additional Properties

--- a/qshift/templates/quarkus-application/template-static.yaml
+++ b/qshift/templates/quarkus-application/template-static.yaml
@@ -4,8 +4,8 @@ apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: quarkus-application
-  title: Create a Quarkus Application
-  description: Create a Quarkus application using https://code.quarkus.io
+  title: Create a Quarkus Application (RHDH)
+  description: Create a Quarkus application for RHDH using https://code.quarkus.io
   tags:
     - quarkus
     - java
@@ -26,13 +26,19 @@ spec:
           description: Unique name of the application
           default: my-quarkus-app
           ui:field: EntityNamePicker
-
         quarkusVersion:
           title: Quarkus version
           type: string
           description: The list of the quarkus supported/recommended
-          ui:field: QuarkusVersionList
-
+          default: 'io.quarkus.platform:3.10'
+          enum:
+            - 'io.quarkus.platform:3.2'
+            - 'io.quarkus.platform:3.8'
+            - 'io.quarkus.platform:3.10'
+          enumNames:
+            - '3.2'
+            - '3.8'
+            - '3.10 (RECOMMENDED)'
         owner:
           title: Owner
           type: string
@@ -58,7 +64,6 @@ spec:
           type: string
           default: io.quarkus
           description: Maven Group ID eg (io.janus)
-
         artifactId:
           title: Artifact ID
           type: string
@@ -69,7 +74,6 @@ spec:
           type: string
           default: 1.0.0-SNAPSHOT
           description: Maven Artifact Version
-
         java_package_name:
           title: Java Package Namespace
           type: string
@@ -80,7 +84,6 @@ spec:
           type: string
           description: Help others understand what this website is for.
           default: A cool quarkus app
-
         javaVersion:
           title: Java Version
           type: string
@@ -92,7 +95,6 @@ spec:
           enumNames:
             - Java 17
             - Java 21
-
         buildTool:
           title: Build Tool
           type: string
@@ -127,7 +129,6 @@ spec:
             - 'PostgreSQL'
             - 'MySQL'
             - 'H2'
-
         healthEndpoint:
           title: Enable health endpoint
           type: boolean
@@ -150,15 +151,30 @@ spec:
           title: Alternative Extensions
           type: array
           description: The list of alternative extensions
-          ui:field: QuarkusExtensionList
-          ui:options:
-            # codeQuarkusUrl: https://code.quarkus.io
-            filter:
-              extensions:
-                - io.quarkus:quarkus-rest-jackson
-                - io.quarkus:quarkus-smallrye-openapi
-                - io.quarkus:quarkus-smallrye-graphql
-                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+          items:
+            type: string
+            enum:
+              - io.quarkus:quarkus-rest-jackson
+              - io.quarkus:quarkus-smallrye-openapi
+              - io.quarkus:quarkus-smallrye-graphql
+              - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+            enumNames:
+              - REST
+              - SmallRye OpenApi
+              - SmallRye GraphQL
+              - REST resources for Hibernate ORM with Panache
+          uniqueItems: true
+          ui:widget: checkboxes
+
+          #ui:field: QuarkusExtensionList
+          #ui:options:
+          #  # codeQuarkusUrl: https://code.quarkus.io
+          #  filter:
+          #    extensions:
+          #      - io.quarkus:quarkus-rest-jackson
+          #      - io.quarkus:quarkus-smallrye-openapi
+          #      - io.quarkus:quarkus-smallrye-graphql
+          #      - io.quarkus:quarkus-hibernate-orm-rest-data-panache
 
         additionalProperties:
           title: Additional Properties

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -30,13 +30,15 @@ spec:
           title: Quarkus version
           type: string
           description: The list of the quarkus supported/recommended
-          default: '17'
+          default: '3.10'
           enum:
-            - '17'
-            - '21'
+            - '3.2'
+            - '3.8'
+            - '3.10'
           enumNames:
-            - Java 17
-            - Java 21
+            - '3.2'
+            - '3.8'
+            - '3.10 (RECOMMENDED)'
         owner:
           title: Owner
           type: string
@@ -86,15 +88,13 @@ spec:
           title: Java Version
           type: string
           description: Java version
-          default: '3.10'
+          default: '17'
           enum:
-            - '3.2'
-            - '3.8'
-            - '3.10'
+            - '17'
+            - '21'
           enumNames:
-            - '3.2'
-            - '3.8'
-            - '3.10 (RECOMMENDED)'
+            - Java 17
+            - Java 21
         buildTool:
           title: Build Tool
           type: string

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -30,7 +30,7 @@ spec:
           title: Quarkus version
           type: string
           description: The list of the quarkus supported/recommended
-          default: '3.10'
+          default: '3.10 (RECOMMENDED)'
           enum:
             - 'io.quarkus.platform:3.2'
             - 'io.quarkus.platform:3.8'
@@ -151,15 +151,25 @@ spec:
           title: Alternative Extensions
           type: array
           description: The list of alternative extensions
-          ui:field: QuarkusExtensionList
-          ui:options:
-            # codeQuarkusUrl: https://code.quarkus.io
-            filter:
-              extensions:
-                - io.quarkus:quarkus-rest-jackson
-                - io.quarkus:quarkus-smallrye-openapi
-                - io.quarkus:quarkus-smallrye-graphql
-                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+          items:
+            type: string
+            enum:
+              - io.quarkus:quarkus-rest-jackson
+              - io.quarkus:quarkus-smallrye-openapi
+              - io.quarkus:quarkus-smallrye-graphql
+              - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+          uniqueItems: true
+          ui:widget: checkboxes
+
+          #ui:field: QuarkusExtensionList
+          #ui:options:
+          #  # codeQuarkusUrl: https://code.quarkus.io
+          #  filter:
+          #    extensions:
+          #      - io.quarkus:quarkus-rest-jackson
+          #      - io.quarkus:quarkus-smallrye-openapi
+          #      - io.quarkus:quarkus-smallrye-graphql
+          #      - io.quarkus:quarkus-hibernate-orm-rest-data-panache
 
         additionalProperties:
           title: Additional Properties

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -30,7 +30,7 @@ spec:
           title: Quarkus version
           type: string
           description: The list of the quarkus supported/recommended
-          default: '3.10 (RECOMMENDED)'
+          default: 'io.quarkus.platform:3.10'
           enum:
             - 'io.quarkus.platform:3.2'
             - 'io.quarkus.platform:3.8'

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -30,7 +30,13 @@ spec:
           title: Quarkus version
           type: string
           description: The list of the quarkus supported/recommended
-          ui:field: QuarkusVersionList
+          default: '17'
+          enum:
+            - '17'
+            - '21'
+          enumNames:
+            - Java 17
+            - Java 21
         owner:
           title: Owner
           type: string
@@ -80,13 +86,15 @@ spec:
           title: Java Version
           type: string
           description: Java version
-          default: '17'
+          default: '3.10'
           enum:
-            - '17'
-            - '21'
+            - '3.2'
+            - '3.8'
+            - '3.10'
           enumNames:
-            - Java 17
-            - Java 21
+            - '3.2'
+            - '3.8'
+            - '3.10 (RECOMMENDED)'
         buildTool:
           title: Build Tool
           type: string

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -158,6 +158,11 @@ spec:
               - io.quarkus:quarkus-smallrye-openapi
               - io.quarkus:quarkus-smallrye-graphql
               - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+            enumNames:
+              - REST
+              - SmallRye OpenApi
+              - SmallRye GraphQL
+              - REST resources for Hibernate ORM with Panache
           uniqueItems: true
           ui:widget: checkboxes
 

--- a/qshift/templates/quarkus-application/template.yaml
+++ b/qshift/templates/quarkus-application/template.yaml
@@ -32,9 +32,9 @@ spec:
           description: The list of the quarkus supported/recommended
           default: '3.10'
           enum:
-            - '3.2'
-            - '3.8'
-            - '3.10'
+            - 'io.quarkus.platform:3.2'
+            - 'io.quarkus.platform:3.8'
+            - 'io.quarkus.platform:3.10'
           enumNames:
             - '3.2'
             - '3.8'


### PR DESCRIPTION
- Use static lists instead of dynamic for quarkus versions and extensions
- See: #51 